### PR TITLE
Have unit test reference proper checker-qual version.

### DIFF
--- a/src/test/java/net/rkunze/maven/compiler/jsr308javac/JavacJSR308CompilerTest.java
+++ b/src/test/java/net/rkunze/maven/compiler/jsr308javac/JavacJSR308CompilerTest.java
@@ -478,7 +478,7 @@ public class JavacJSR308CompilerTest
     {
         List<String> cp = getClasspath();
 
-        File file = getLocalArtifactPath( "org.checkerframework", "checker-qual", "1.8.3", "jar" );
+        File file = getLocalArtifactPath( "org.checkerframework", "checker-qual", "1.8.8", "jar" );
 
         assertTrue( "test prerequisite: checker-qual library must be available in local repository, expected "
                         + file.getAbsolutePath(), file.canRead() );


### PR DESCRIPTION
If the `checker-qual` version referenced by the unit tests doesn't match the version declared in `pom.xml`, then `JavacJSR308CompilerTest` will fail unless (through chance) the user has previously downloaded the other version as well.

Following this change, the following command should complete successfully: `mvn clean install -Dmaven.repo.local=/tmp/empty-directory`.
